### PR TITLE
Bug fix 02: Change answer button size in desktop

### DIFF
--- a/src/components/AnswerItem.vue
+++ b/src/components/AnswerItem.vue
@@ -28,8 +28,8 @@ button {
 
 @media only screen and (min-width: 769px) {
   button {
-    width: 200px;
-    height: 65px;
+    width: 250px;
+    height: 75px;
     border-radius: 15px;
     font-size: 2em;
   }


### PR DESCRIPTION
Increased the size slightly in desktop version, should fix the problem with words being too long. Might have to revisit if we got some massive words in the future.